### PR TITLE
Use correct docker image to build bionic stemcells

### DIFF
--- a/pipelines/ubuntu-xenial/pipeline.yml
+++ b/pipelines/ubuntu-xenial/pipeline.yml
@@ -153,6 +153,12 @@ jobs:
       OPERATING_SYSTEM_VERSION: (@= stemcell.os @)
     privileged: true
     task: build
+    vars:
+      #@ if stemcell.os == "bionic":
+      image_os_tag: (@= stemcell.os @)
+      #@ else:
+      image_os_tag: latest
+      #@ end
   - params:
       files:
       - os-image/(@= stemcell.os_name @).tgz
@@ -377,6 +383,12 @@ jobs:
       STEMCELL_BUCKET: bosh-core-stemcells-candidate
     privileged: true
     task: create-stemcell
+    vars:
+      #@ if stemcell.os == "bionic":
+      image_os_tag: (@= stemcell.os @)
+      #@ else:
+      image_os_tag: latest
+      #@ end
   - in_parallel:
     - attempts: 3
       params:
@@ -422,6 +434,12 @@ jobs:
       STEMCELL_BUCKET: bosh-core-stemcells-candidate
     privileged: true
     task: create-stemcell
+    vars:
+      #@ if stemcell.os == "bionic":
+      image_os_tag: (@= stemcell.os @)
+      #@ else:
+      image_os_tag: latest
+      #@ end
   - in_parallel:
     - attempts: 3
       params:
@@ -467,6 +485,12 @@ jobs:
       STEMCELL_BUCKET: bosh-core-stemcells-candidate
     privileged: true
     task: create-stemcell
+    vars:
+      #@ if stemcell.os == "bionic":
+      image_os_tag: (@= stemcell.os @)
+      #@ else:
+      image_os_tag: latest
+      #@ end
   - in_parallel:
     - attempts: 3
       params:
@@ -512,6 +536,12 @@ jobs:
       STEMCELL_BUCKET: bosh-core-stemcells-candidate
     privileged: true
     task: create-stemcell
+    vars:
+      #@ if stemcell.os == "bionic":
+      image_os_tag: (@= stemcell.os @)
+      #@ else:
+      image_os_tag: latest
+      #@ end
   - in_parallel:
     - attempts: 3
       params:
@@ -557,6 +587,12 @@ jobs:
       STEMCELL_BUCKET: bosh-core-stemcells-candidate
     privileged: true
     task: create-stemcell
+    vars:
+      #@ if stemcell.os == "bionic":
+      image_os_tag: (@= stemcell.os @)
+      #@ else:
+      image_os_tag: latest
+      #@ end
   - in_parallel:
     - attempts: 3
       params:
@@ -602,6 +638,12 @@ jobs:
       STEMCELL_BUCKET: bosh-core-stemcells-candidate
     privileged: true
     task: create-stemcell
+    vars:
+      #@ if stemcell.os == "bionic":
+      image_os_tag: (@= stemcell.os @)
+      #@ else:
+      image_os_tag: latest
+      #@ end
   - in_parallel:
     - attempts: 3
       params:
@@ -647,6 +689,12 @@ jobs:
       STEMCELL_BUCKET: bosh-core-stemcells-candidate
     privileged: true
     task: create-stemcell
+    vars:
+      #@ if stemcell.os == "bionic":
+      image_os_tag: (@= stemcell.os @)
+      #@ else:
+      image_os_tag: latest
+      #@ end
   - in_parallel:
     - attempts: 3
       params:
@@ -693,6 +741,12 @@ jobs:
       STEMCELL_BUCKET: bosh-core-stemcells-candidate
     privileged: true
     task: create-stemcell
+    vars:
+      #@ if stemcell.os == "bionic":
+      image_os_tag: (@= stemcell.os @)
+      #@ else:
+      image_os_tag: latest
+      #@ end
   - in_parallel:
     - attempts: 3
       params:

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -5,6 +5,7 @@ image_resource:
   type: registry-image
   source:
     repository: bosh/os-image-stemcell-builder
+    tag: "((image_os_tag))"
 
 inputs:
   - name: bosh-linux-stemcell-builder

--- a/tasks/os-images/build.yml
+++ b/tasks/os-images/build.yml
@@ -5,6 +5,7 @@ image_resource:
   type: registry-image
   source:
     repository: bosh/os-image-stemcell-builder
+    tag: "((image_os_tag))"
 
 inputs:
   - name: bosh-linux-stemcell-builder


### PR DESCRIPTION
Bionic stemcells are currently build with a xenial docker image. This leads to problems when building stemcells locally and created vms behave differently, see https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/141.
 
The image tag for bionic got lost with commit https://github.com/cloudfoundry/bosh-stemcells-ci/commit/78bd0905f06473985f6471da734e6a5f0dd2f1c5.

This PR will set the tag to either "latest" for xenial and "bionic" for bionic.

Docker image tags are taken from https://hub.docker.com/r/bosh/os-image-stemcell-builder/tags?page=1&ordering=last_updated
