### PR TITLE
Make sure usn resources use the proper os_version

### DIFF
--- a/pipelines/ubuntu-bionic/pipeline.yml
+++ b/pipelines/ubuntu-bionic/pipeline.yml
@@ -1450,7 +1450,7 @@ resources:
   type: git
 - name: (@= stemcell.os @)-usn-low-medium
   source:
-    os: ubuntu-16.04-lts
+    os: ubuntu-(@= stemcell.os_version @)-lts
     priorities:
     - low
     - medium
@@ -1476,7 +1476,7 @@ resources:
     versioned_file: nimbus-vcenter-vars.yml
 - name: (@= stemcell.os @)-usn
   source:
-    os: ubuntu-16.04-lts
+    os: ubuntu-(@= stemcell.os_version @)-lts
     priorities:
     - high
     - critical

--- a/pipelines/ubuntu-bionic/stemcells.yml
+++ b/pipelines/ubuntu-bionic/stemcells.yml
@@ -14,6 +14,7 @@ stemcells:
   initial_version: "0.0.0"
   include_alicloud: false
   os: bionic
+  os_version: "18.04"
   os_name: ubuntu-bionic
 
 - version: "0.x"
@@ -29,4 +30,5 @@ stemcells:
   initial_version: "0.0.0"
   include_alicloud: true
   os: bionic
+  os_version: "18.04"
   os_name: ubuntu-bionic


### PR DESCRIPTION
These changes where already manually applied to the pipeline which is why we now have a green build here: https://main.bosh-ci.cf-app.com/teams/main/pipelines/bosh:stemcells:ubuntu-bionic/jobs/notify-of-usn/builds/8