### PR TITLE
adding a aws ami cleanup task

### DIFF
--- a/pipelines/publisher/pipeline.yml
+++ b/pipelines/publisher/pipeline.yml
@@ -8,6 +8,18 @@ do:
 
 #@yaml/text-templated-strings
 ---
+#@ def cleanup_unpublished_light_stemcells(name, prefix, region):
+file: bosh-stemcells-ci/tasks/light-aws/cleanup-ami.yml
+task: cleanup-amis-in-(@= name @)
+params:
+  ami_access_key: ((aws_publish_(@= prefix @)_access_key))
+  ami_secret_key: ((aws_publish_(@= prefix @)_secret_key))
+  ami_region: ((aws_publish_(@= region @)_region))
+  ami_older_than_days: 60
+  ami_keep_latest: 5
+  os_name: (@= stemcell.os @)
+#@ end
+
 #@ def build_light_aws_stemcell(name, builder_src, input_stemcell, output_stemcell, prefix, region, bucket_prefix, tag, ami_destinations):
 file: bosh-stemcells-ci/tasks/light-aws/build.yml
 task: #@ name
@@ -230,8 +242,24 @@ groups:
   - build-light-google-(@= stemcell.os @)-(@= str(stemcell.version) @)
   - publish-(@= stemcell.os @)-(@= str(stemcell.version) @)
 #@ end
+- name: cleanup-aws-light-stemcells
+  jobs:
+  #@ for stemcell in data.values.oss:
+  - cleanup-unpublished-(@= stemcell.os @)-aws-light-stemcells
+  #@ end
 
 jobs:
+#@ for stemcell in data.values.oss:
+- name: cleanup-unpublished-(@= stemcell.os @)-aws-light-stemcells
+  plan:
+  - get: every-3-weeks-on-monday
+    trigger: true
+  - get: bosh-stemcells-ci
+  - #@ cleanup_unpublished_light_stemcells("aws", "us", "us")
+  - #@ cleanup_unpublished_light_stemcells("us-goverment", "us-gov", "us-gov")
+  - #@ cleanup_unpublished_light_stemcells("china", "cn", "cn_north")
+#@ end
+
 - name: test-aws-unit
   plan:
   - get: bosh-stemcells-ci
@@ -462,6 +490,16 @@ resource_types:
   type: docker-image
 
 resources:
+- name: every-3-weeks-on-monday
+  type: time
+  source:
+    days:
+      - Monday
+    interval: 499h
+    location: America/Los_Angeles
+    start: "6:00"
+    stop: "8:30"
+
 - name: gh-release-oss
   type: github-release
   source:

--- a/tasks/light-aws/cleanup-ami.sh
+++ b/tasks/light-aws/cleanup-ami.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+export AWS_ACCESS_KEY_ID=$ami_access_key
+export AWS_SECRET_ACCESS_KEY=$ami_secret_key
+export AWS_DEFAULT_REGION=$ami_region
+
+: ${ami_older_than_days:?}
+: ${ami_keep_latest:?}
+: ${os_name:?}
+
+__PASTDUE=$(date --date="$ami_older_than_days days ago" +"%Y-%m-%d")
+
+ami_destinations="$(aws ec2 describe-regions --output text --query "Regions[?RegionName][].RegionName")"
+
+for region in $ami_destinations; do
+
+    # 'ami_ids' array should be orderered by creation date
+    ami_list=$(aws ec2 describe-images \
+            --owners self \
+            --output json \
+            --region $region \
+            --filters "Name=name,Values=BOSH*" "Name=tag:published,Values=false" "Name=tag:distro,Values=$os_name" \
+            --query 'sort_by(Images,&CreationDate)[?CreationDate<`'"$__PASTDUE"'`].{ImageId: ImageId, date:CreationDate, SnapshotId: BlockDeviceMappings[0].Ebs.SnapshotId,Version: Tags[?Key==`name`]|[0].Value}' | jq 'reverse | del(.[env.ami_keep_latest|tonumber])')
+
+    # 'ami_list' is a json array of objects, each object is an ami and its snapshot
+    for row in $(echo "${ami_list}" | jq -r '.[] | @base64'); do
+      _jq() {
+        echo ${row} | base64 --decode | jq -r ${1}
+        }
+      echo "
+      ===============================================
+      Cleaning up Ami and its snashots in $region
+      Ami id:        $(_jq '.ImageId')
+      Version:       $(_jq '.Version')
+      Creation data: $(_jq '.date')
+      Snapshot id:   $(_jq '.SnapshotId')
+      "
+
+      aws ec2 deregister-image --image-id $(_jq '.ImageId')
+
+      aws ec2 delete-snapshot --snapshot-id $(_jq '.SnapshotId')
+    done
+
+done

--- a/tasks/light-aws/cleanup-ami.yml
+++ b/tasks/light-aws/cleanup-ami.yml
@@ -1,0 +1,20 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: bosh/integration
+    tag: main
+
+inputs:
+- name: bosh-stemcells-ci
+
+run:
+  path: bosh-stemcells-ci/tasks/light-aws/cleanup-ami.sh
+params:
+  ami_region:                 "eu-central-1" # AWS default region
+  ami_access_key:             ""
+  ami_secret_key:             ""
+  ami_older_than_days:        "60" # Number of days AMI to keep excluding those currently being running
+  ami_keep_latest:            "5"  # Number of previous AMI to keep excluding those currently being running
+  os_name:                    ""   # e.g ubuntu-jammy


### PR DESCRIPTION
i thing this belongs in the publisher pipeline.
for now this only cleans up unpublished pipelines.

we keep at least the last unpublished ami's
and they should be at least 60 days or older.
this parameters are configurable so we can adjust this easy on a later stage.

will give the following output in the pipeline
```
===============================
      Cleaning up Ami's and its snashots in ap-south-1
      Ami id:        ami-0fe2ee313d8d95799
      Version:       ubuntu-bionic-1.91
      Creation data: 2022-07-11T12:03:32.000Z
      Snapshot id:   snap-03f41133b6582a550

===============================
      Cleaning up Ami's and its snashots in eu-north-1
      Ami id:        ami-0b8bb6d4d6d5e0227
      Version:       ubuntu-bionic-1.145
      Creation data: 2022-11-16T11:25:08.000Z
      Snapshot id:   snap-055ac03f2d29a2b62
```