### PR TITLE
Re-enable aws dev stemcell cleanup for gov and china regions

### DIFF
--- a/pipelines/publisher/pipeline.yml
+++ b/pipelines/publisher/pipeline.yml
@@ -256,9 +256,8 @@ jobs:
     trigger: true
   - get: bosh-stemcells-ci
   - #@ cleanup_unpublished_light_stemcells("aws", "us", "us")
-#! disabled until we re tagging gov and china ami's properly
-#!  - #@ cleanup_unpublished_light_stemcells("us-goverment", "us-gov", "us-gov")
-#!  - #@ cleanup_unpublished_light_stemcells("china", "cn", "cn_north")
+  - #@ cleanup_unpublished_light_stemcells("us-goverment", "us-gov", "us-gov")
+  - #@ cleanup_unpublished_light_stemcells("china", "cn", "cn_north")
 #@ end
 
 - name: test-aws-unit


### PR DESCRIPTION
We believe everything is now properly tagged as "published=true" in these regions and this is safe to re-enable