### PR TITLE
Add azure-storage-cli to the stemcells

### DIFF
--- a/pipelines/ubuntu-jammy/pipeline.yml
+++ b/pipelines/ubuntu-jammy/pipeline.yml
@@ -1401,3 +1401,9 @@ resources:
   source:
     regexp: s3cli-(.*)-linux-amd64
     bucket: bosh-s3cli-artifacts
+- name: bosh-blobstore-azure-storage
+  type: s3
+  source:
+    regexp: azure-storage-cli-(.*)-linux-amd64
+    bucket: bosh-azure-storage-cli-artifacts
+

--- a/pipelines/ubuntu-jammy/stemcells.yml
+++ b/pipelines/ubuntu-jammy/stemcells.yml
@@ -29,3 +29,5 @@ blobstore_types:
 - dav
 - gcs
 - s3
+- azure-storage
+


### PR DESCRIPTION
Add blobstore client for Azure aka [azure-storage-cli](https://github.com/cloudfoundry/bosh-azure-storage-cli) binary to the stemcells.

Related PRs
 - bosh-linux-stemcell-builder [Add azure-storage-cli to the stemcells](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/295)