### PR TITLE
do not tag on candidate builds

### DIFF
--- a/pipelines/ubuntu-jammy/pipeline.yml
+++ b/pipelines/ubuntu-jammy/pipeline.yml
@@ -590,11 +590,6 @@ jobs:
       AWS_ENDPOINT: "https://storage.googleapis.com"
       S3_API_ENDPOINT: storage.googleapis.com
   - in_parallel:
-    - put: bosh-linux-stemcell-builder-push-(@= stemcell.version @)
-      params:
-        only_tag: true
-        repository: bosh-linux-stemcell-builder
-        tag: version-tag/tag
     - put: stemcells-index
       params:
         rebase: true


### PR DESCRIPTION
why are we createing git tags on candidate stemcell versions in the aggregate steps

this pr will remove this beheviour