### PR TITLE
Create a timestamp at the start of stemcell building to limit snapshot apt repo packages

### DIFF
--- a/pipelines/publisher/pipeline.yml
+++ b/pipelines/publisher/pipeline.yml
@@ -495,10 +495,6 @@ jobs:
       tag: release-metadata/tag
     put: gh-release-oss
   - params:
-      rebase: true
-      repository: bosh-linux-stemcell-builder
-    put: bosh-linux-stemcell-builder-(@= stemcell.os @)-(@= str(stemcell.version) @).x
-  - params:
       acl: public-read
       file: usn-log/usn-log.json
     put: usn-log-(@= stemcell.os @)-(@= str(stemcell.version) @).x

--- a/pipelines/ubuntu-jammy/pipeline.yml
+++ b/pipelines/ubuntu-jammy/pipeline.yml
@@ -240,6 +240,7 @@ jobs:
 
 - name: build-os-image-(@= stemcell.version @)
   plan:
+  - put: build-time
   - get: bosh-stemcells-ci
   - get: bosh-linux-stemcell-builder
     resource: bosh-linux-stemcell-builder-(@= stemcell.version @)
@@ -282,9 +283,9 @@ jobs:
     trigger: true
     passed:
     - build-os-image-(@= stemcell.version @)
-  - get: stemcell-trigger-(@= stemcell.version @)
+  - get: build-time
     passed:
-    - build-os-image-(@= stemcell.version @)
+      - build-os-image-(@= stemcell.version @)
     trigger: true
   - get: os-image-tarball
     resource: os-image-tarball-(@= stemcell.version @)
@@ -304,10 +305,9 @@ jobs:
     - build-os-image-(@= stemcell.version @)
     resource: bosh-linux-stemcell-builder-(@= stemcell.version @)
     trigger: true
-  - get: stemcell-trigger-(@= stemcell.version @)
+  - get: build-time
     passed:
-    - test-unit-(@= stemcell.version @)
-    - build-os-image-(@= stemcell.version @)
+      - test-unit-(@= stemcell.version @)
     trigger: true
   - get: version
     params:
@@ -343,8 +343,9 @@ jobs:
         passed:
         - build-google-kvm-(@= stemcell.version @)
         resource: google-kvm-(@= stemcell.version @)
-      - get: stemcell-trigger-(@= stemcell.version @)
+      - get: build-time
         passed:
+          - build-os-image-(@= stemcell.version @)
       #@ for iaas in stemcell.include_iaas:
         - build-(@= iaas.iaas @)-(@= iaas.hypervisor @)-(@= stemcell.version @)
       #@ end
@@ -390,7 +391,7 @@ jobs:
       resource: version-(@= stemcell.version @)
       trigger: true
     - get: bosh-stemcells-ci
-    - get: stemcell-trigger-(@= stemcell.version @)
+    - get: build-time
       passed:
       - build-stemcell-(@= stemcell.version @)
       trigger: true
@@ -472,7 +473,7 @@ jobs:
         - build-(@= iaas.iaas @)-(@= iaas.hypervisor @)-(@= stemcell.version @)-fips
       #@ end
         resource: version-(@= stemcell.version @)
-      - get: stemcell-trigger-(@= stemcell.version @)
+      - get: build-time
         passed:
       #@ for iaas in stemcell.include_iaas:
         - build-(@= iaas.iaas @)-(@= iaas.hypervisor @)-(@= stemcell.version @)
@@ -538,11 +539,15 @@ jobs:
       - bats-(@= stemcell.version @)
       resource: bosh-linux-stemcell-builder-(@= stemcell.version @)
     - get: stemcells-index
-    - get: stemcell-trigger-(@= stemcell.version @)
+    - get: build-time
       passed:
       - test-stemcells-(@= stemcell.version @)-ipv4
       - bats-(@= stemcell.version @)
       trigger: true
+    - get: os-image-stemcell-builder-(@= stemcell.os @)
+  - task: commit-build-time
+    file: bosh-stemcells-ci/tasks/commit-build-time.yml
+    image: os-image-stemcell-builder-(@= stemcell.os @)
   - task: assert-version-aligns
     file: bosh-stemcells-ci/tasks/assert-version-aligns.yml
   - task: copy-fips-artifacts
@@ -586,7 +591,8 @@ jobs:
       AWS_ENDPOINT: "https://storage.googleapis.com"
       S3_API_ENDPOINT: storage.googleapis.com
   - in_parallel:
-    - put: bosh-linux-stemcell-builder-push-(@= stemcell.version @)
+    - put: bosh-linux-stemcell-builder-push-tags-(@= stemcell.version @)
+      no_get: true
       params:
         only_tag: true
         repository: bosh-linux-stemcell-builder
@@ -852,6 +858,13 @@ resources:
     initial_version: '0'
 
 #@ if stemcell.version != "master":
+- name: bosh-linux-stemcell-builder-push-tags-(@= stemcell.version @)
+  type: git
+  source:
+    fake_param_to_bust_global_resource_cache: true
+    private_key: ((bosh_src_key.private_key))
+    uri: git@github.com:cloudfoundry/bosh-linux-stemcell-builder
+
 - name: every-3-weeks-on-monday-(@= stemcell.version @)
   type: time
   source:
@@ -867,6 +880,9 @@ resources:
 - name: hourly
   source:
     interval: 1h
+  type: time
+
+- name: build-time
   type: time
 
 - name: bosh-linux-stemcell-builder-ci

--- a/tasks/commit-build-time.sh
+++ b/tasks/commit-build-time.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+build_time="$(cat ./build-time/timestamp)"
+formatted_build_time="$(date --date "${build_time%.*}" +%Y%m%dT%H%M%SZ)"
+
+pushd bosh-linux-stemcell-builder
+  echo "${formatted_build_time}" > build_time.txt
+  git add -A
+  git config --global user.email "ci@localhost"
+  git config --global user.name "CI Bot"
+  git commit -m "Commit Build Time"
+popd

--- a/tasks/commit-build-time.yml
+++ b/tasks/commit-build-time.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+
+inputs:
+  - name: bosh-linux-stemcell-builder
+  - name: build-time
+
+outputs:
+  - name: bosh-linux-stemcell-builder
+
+run:
+  path: bosh-stemcells-ci/tasks/commit-build-time.sh

--- a/tasks/os-images/build.sh
+++ b/tasks/os-images/build.sh
@@ -19,6 +19,10 @@ check_param OPERATING_SYSTEM_VERSION
 
 OS_IMAGE_NAME=$OPERATING_SYSTEM_NAME-$OPERATING_SYSTEM_VERSION
 OS_IMAGE=$TASK_DIR/os-image/$OS_IMAGE_NAME.tgz
+if [ -f "${TASK_DIR}/build-time/timestamp" ]; then
+  build_time="$(cat "${TASK_DIR}/build-time/timestamp")"
+  export BUILD_TIME="$(date --date "${build_time%.*}" +%Y%m%dT%H%M%SZ)"
+fi
 
 sudo chown -R ubuntu .
 sudo chown -R ubuntu:ubuntu /mnt

--- a/tasks/os-images/build.yml
+++ b/tasks/os-images/build.yml
@@ -10,6 +10,8 @@ image_resource:
 inputs:
   - name: bosh-linux-stemcell-builder
   - name: bosh-stemcells-ci
+  - name: build-time
+    optional: true
 
 outputs:
 - name: os-image


### PR DESCRIPTION
See https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/317

Use that timestamp to lock down the snapshot apt repo for stemcell building, and then commit it as part of the tag at the end so if somebody checks out that tag, they will be able to pull the same packages later.

The triggers throughout the pipeline are changed from stemcell-trigger to the new build_time resource

Added `fake_param_to_bust_global_resource_cache` because even if you have two separate resources, if they have the same params, one can pollute the versions of the other if global concourse resources are enabled. This causes the push of the tag commit to appear in the normal bosh-linux-stemcell-builder resource, which causes problems.

Removed the push to `bosh-linux-stemcell-builder` during the publish step. This repo doesn't seem to be modified during publish, so it was getting and pushing the same commit, and not adding tags or doing any work as far as I can tell.