### PR TITLE
Remove unused resource (bosh-google-light-stemcell-builder)

### DIFF
--- a/pipelines/publisher/pipeline.yml
+++ b/pipelines/publisher/pipeline.yml
@@ -75,25 +75,6 @@ in_parallel:
   #@ end
 #@ end
 
-#@ def get_google_light_inputs(stemcell_os, stemcell_version):
-in_parallel:
-- get: stemcell
-  params:
-    include_files:
-    - bosh-stemcell-*-google-kvm-(@= stemcell_os @)-go_agent.tgz
-  resource: candidate-(@= stemcell_os @)-stemcell-(@= str(stemcell_version) @)
-  trigger: true
-  version: every
-- get: builder-src
-  passed:
-  - concourse-alignment
-  resource: light-google-builder-src
-- get: bosh-cli
-- get: bosh-stemcells-ci
-- get: bosh-cpi-release
-  resource: bosh-google-cpi-release
-#@ end
-
 #@ def deploy_skeletal_google_light_stemcell(terraform_resource, credentials):
 do:
 - params:
@@ -217,7 +198,6 @@ groups:
   - test-aws-unit
   - test-aws-drivers
   - test-aws-integration
-  - concourse-alignment
   #@ for stemcell in data.values.oss:
     #@ if stemcell.build_aws:
   - build-light-aws-(@= stemcell.os @)-(@= str(stemcell.version) @)
@@ -336,14 +316,6 @@ jobs:
       ami_keep_latest: 0
       snapshot_id: ((aws_test_snapshot_fixture_id))
 
-- name: concourse-alignment
-  plan:
-  - get: builder-src
-    resource: light-google-builder-src
-    trigger: true
-  serial: true
-
-
 #@ for stemcell in data.values.oss:
   #@ if stemcell.build_aws:
 - name: build-light-aws-(@= stemcell.os @)-(@= str(stemcell.version) @)
@@ -374,7 +346,6 @@ jobs:
 
 - name: build-light-google-(@= stemcell.os @)-(@= str(stemcell.version) @)
   plan:
-  - #@ get_google_light_inputs(stemcell.os, str(stemcell.version))
   - task: make-raw-from-heavy-stemcell
     file: bosh-stemcells-ci/tasks/light-google/make-raw-from-heavy-stemcell.yml
     params:
@@ -650,11 +621,6 @@ resources:
   source:
     repository: cloudfoundry/bosh-google-cpi-release
   type: bosh-io-release
-- name: light-google-builder-src
-  source:
-    branch: master
-    uri: https://github.com/cloudfoundry/bosh-google-light-stemcell-builder.git
-  type: git
 - name: light-google-environment-oss
   source:
     delete_on_failure: true

--- a/tasks/light-google/build-light-stemcell.yml
+++ b/tasks/light-google/build-light-stemcell.yml
@@ -7,7 +7,6 @@ image_resource:
     repository: bosh/light-stemcell-builder
 
 inputs:
-  - name: builder-src
   - name: bosh-stemcells-ci
   - name: stemcell
 

--- a/tasks/light-google/create-public-image.yml
+++ b/tasks/light-google/create-public-image.yml
@@ -7,7 +7,6 @@ image_resource:
     repository: boshcpi/gce-cpi-release
 
 inputs:
-  - name: builder-src
   - name: bosh-stemcells-ci
   - name: stemcell
   - name: base-oss-google-ubuntu-stemcell

--- a/tasks/light-google/deploy-skeletal.yml
+++ b/tasks/light-google/deploy-skeletal.yml
@@ -11,7 +11,6 @@ inputs:
   - name: bosh-cli
   - name: bosh-stemcells-ci
   - name: bosh-cpi-release
-  - name: builder-src
   - name: light-stemcell
   - name: terraform
 

--- a/tasks/light-google/destroy-skeletal.yml
+++ b/tasks/light-google/destroy-skeletal.yml
@@ -10,7 +10,6 @@ image_resource:
 inputs:
   - name: deployment-state
   - name: bosh-stemcells-ci
-  - name: builder-src
 
 run:
   path: bosh-stemcells-ci/tasks/light-google/destroy-skeletal.sh

--- a/tasks/light-google/make-raw-from-heavy-stemcell.yml
+++ b/tasks/light-google/make-raw-from-heavy-stemcell.yml
@@ -7,7 +7,6 @@ image_resource:
     repository: bosh/light-stemcell-builder
 
 inputs:
-  - name: builder-src
   - name: bosh-stemcells-ci
   - name: stemcell
 

--- a/tasks/light-google/publish-stemcell-and-checksum.yml
+++ b/tasks/light-google/publish-stemcell-and-checksum.yml
@@ -9,7 +9,6 @@ image_resource:
 inputs:
   - name: light-stemcell
   - name: bosh-stemcells-ci
-  - name: builder-src
   - name: stemcells-index
 
 outputs:


### PR DESCRIPTION
The `cloudfoundry/bosh-google-light-stemcell-builder` repo is threaded through various jobs and tasks in the publisher pipeline but it is never actually used by any of the tasks.

We also recommend that [cloudfoundry/bosh-google-light-stemcell-builder](https://github.com/cloudfoundry/bosh-google-light-stemcell-builder) be archived once this change lands.