### PR TITLE
create copy_keys array from the iaas's configured in stemcells.yml

### DIFF
--- a/pipelines/ubuntu-jammy/pipeline.yml
+++ b/pipelines/ubuntu-jammy/pipeline.yml
@@ -519,9 +519,10 @@ jobs:
       AWS_ACCESS_KEY_ID: ((hmac_accesskey))
       AWS_SECRET_ACCESS_KEY: ((hmac_secret))
       COMMIT_PREFIX: candidate
-      COPY_KEYS: |
-        aws/bosh-stemcell-%s-aws-xen-hvm-ubuntu-(@= data.values.stemcell_details.os @)-fips-go_agent.tgz
-        google/bosh-stemcell-%s-google-kvm-ubuntu-(@= data.values.stemcell_details.os @)-fips-go_agent.tgz
+      COPY_KEYS:
+      #@ for iaas in data.values.stemcell_details.include_fips_iaas:
+        - (@= iaas.iaas @)/bosh-stemcell-%s-(@= iaas.iaas @)-(@= iaas.hypervisor @)-(@= data.values.stemcell_details.os_name @)-fips-go_agent.tgz
+      #@ end
       FROM_BUCKET_NAME: bosh-core-stemcells-candidate-fips
       FROM_INDEX: dev
       OS_NAME: ubuntu
@@ -536,15 +537,10 @@ jobs:
       AWS_ACCESS_KEY_ID: ((hmac_accesskey))
       AWS_SECRET_ACCESS_KEY: ((hmac_secret))
       COMMIT_PREFIX: candidate
-      COPY_KEYS: |
-        aws/bosh-stemcell-%s-aws-xen-hvm-ubuntu-(@= data.values.stemcell_details.os @)-go_agent.tgz
-        google/bosh-stemcell-%s-google-kvm-ubuntu-(@= data.values.stemcell_details.os @)-go_agent.tgz
-        openstack/bosh-stemcell-%s-openstack-kvm-ubuntu-(@= data.values.stemcell_details.os @)-go_agent.tgz
-        openstack/bosh-stemcell-%s-openstack-kvm-ubuntu-(@= data.values.stemcell_details.os @)-go_agent-raw.tgz
-        warden/bosh-stemcell-%s-warden-boshlite-ubuntu-(@= data.values.stemcell_details.os @)-go_agent.tgz
-        vsphere/bosh-stemcell-%s-vsphere-esxi-ubuntu-(@= data.values.stemcell_details.os @)-go_agent.tgz
-        vcloud/bosh-stemcell-%s-vcloud-esxi-ubuntu-(@= data.values.stemcell_details.os @)-go_agent.tgz
-        azure/bosh-stemcell-%s-azure-hyperv-ubuntu-(@= data.values.stemcell_details.os @)-go_agent.tgz
+      COPY_KEYS:
+      #@ for iaas in data.values.stemcell_details.include_iaas:
+        - (@= iaas.iaas @)/bosh-stemcell-%s-(@= iaas.iaas @)-(@= iaas.hypervisor @)-(@= data.values.stemcell_details.os_name @)-go_agent.tgz
+      #@ end
       FROM_BUCKET_NAME: bosh-core-stemcells-candidate
       FROM_INDEX: dev
       OS_NAME: ubuntu

--- a/pipelines/ubuntu-noble/pipeline.yml
+++ b/pipelines/ubuntu-noble/pipeline.yml
@@ -454,9 +454,10 @@ jobs:
       AWS_ACCESS_KEY_ID: ((hmac_accesskey))
       AWS_SECRET_ACCESS_KEY: ((hmac_secret))
       COMMIT_PREFIX: candidate
-      COPY_KEYS: |
-        aws/bosh-stemcell-%s-aws-xen-hvm-ubuntu-(@= data.values.stemcell_details.os @)-fips.tgz
-        google/bosh-stemcell-%s-google-kvm-ubuntu-(@= data.values.stemcell_details.os @)-fips.tgz
+      COPY_KEYS:
+      #@ for iaas in data.values.stemcell_details.include_fips_iaas:
+        - (@= iaas.iaas @)/bosh-stemcell-%s-(@= iaas.iaas @)-(@= iaas.hypervisor @)-(@= data.values.stemcell_details.os_name @)-fips.tgz
+      #@ end
       FROM_BUCKET_NAME: bosh-core-stemcells-candidate-fips
       FROM_INDEX: dev
       OS_NAME: ubuntu
@@ -471,15 +472,10 @@ jobs:
       AWS_ACCESS_KEY_ID: ((hmac_accesskey))
       AWS_SECRET_ACCESS_KEY: ((hmac_secret))
       COMMIT_PREFIX: candidate
-      COPY_KEYS: |
-        aws/bosh-stemcell-%s-aws-xen-hvm-ubuntu-(@= data.values.stemcell_details.os @).tgz
-        google/bosh-stemcell-%s-google-kvm-ubuntu-(@= data.values.stemcell_details.os @).tgz
-        openstack/bosh-stemcell-%s-openstack-kvm-ubuntu-(@= data.values.stemcell_details.os @).tgz
-        openstack/bosh-stemcell-%s-openstack-kvm-ubuntu-(@= data.values.stemcell_details.os @)-raw.tgz
-        warden/bosh-stemcell-%s-warden-boshlite-ubuntu-(@= data.values.stemcell_details.os @).tgz
-        vsphere/bosh-stemcell-%s-vsphere-esxi-ubuntu-(@= data.values.stemcell_details.os @).tgz
-        vcloud/bosh-stemcell-%s-vcloud-esxi-ubuntu-(@= data.values.stemcell_details.os @).tgz
-        azure/bosh-stemcell-%s-azure-hyperv-ubuntu-(@= data.values.stemcell_details.os @).tgz
+      COPY_KEYS:
+      #@ for iaas in data.values.stemcell_details.include_iaas:
+        - (@= iaas.iaas @)/bosh-stemcell-%s-(@= iaas.iaas @)-(@= iaas.hypervisor @)-(@= data.values.stemcell_details.os_name @).tgz
+      #@ end
       FROM_BUCKET_NAME: bosh-core-stemcells-candidate
       FROM_INDEX: dev
       OS_NAME: ubuntu

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -51,10 +51,20 @@ if [ -n "${AWS_ROLE_ARN}" ]; then
   export AWS_PROFILE=resource_account
 fi
 
+# Parse the JSON array into a Bash array
+COPY_KEYS_ARRAY=($(echo "$COPY_KEYS" | jq -r '.[]'))
+
+if [ ${#COPY_KEYS_ARRAY[@]} -eq 0 ]; then
+    echo "COPY_KEYS is empty. No files to process."
+    exit 1  # Exit or handle as needed
+fi
+
 if [ "$FROM_BUCKET_NAME" == "$TO_BUCKET_NAME" ]; then
   echo "Skipping upload since buckets are the same..."
+elif [ ${#COPY_KEYS_ARRAY[@]} -eq 0 ]; then
+  echo "Skipping upload since COPY_KEYS is empty..."
 else
-  for file in $COPY_KEYS ; do
+  for file in "${COPY_KEYS_ARRAY[@]}"; do
     file="${file/\%s/$VERSION}"
 
     echo "$file"


### PR DESCRIPTION
due to ytt limitation we needed to make this array instead of a list

this will break the xenial pipeline as it does not use the new stemcell.yml configuration
as xenial is now really EOL i doubt we need to really put effort in to this.