### PR TITLE
Add pipeline step to clean up old published stemcells

### DIFF
--- a/pipelines/publisher/pipeline.yml
+++ b/pipelines/publisher/pipeline.yml
@@ -19,6 +19,16 @@ params:
   ami_keep_latest: 5
   os_name: (@= stemcell.os @)
 #@ end
+#@ def cleanup_old_published_light_stemcells(name, prefix, region):
+file: bosh-stemcells-ci/tasks/light-aws/cleanup-ami.yml
+task: cleanup-amis-in-(@= name @)
+params:
+  ami_access_key: ((aws_publish_(@= prefix @)_access_key))
+  ami_secret_key: ((aws_publish_(@= prefix @)_secret_key))
+  ami_region: ((aws_publish_(@= region @)_region))
+  ami_older_than_days: 1095
+  remove_public_images: true
+#@ end
 
 #@ def build_light_aws_stemcell(name, builder_src, input_stemcell, output_stemcell, prefix, region, bucket_prefix, tag, ami_destinations, efi):
 file: bosh-stemcells-ci/tasks/light-aws/build.yml
@@ -246,6 +256,14 @@ groups:
   #@ end
 
 jobs:
+- name: cleanup-published-aws-light-stemcells-older-than-three-years
+  serial: true
+  plan:
+  - get: every-week-on-monday
+    trigger: true
+  - get: bosh-stemcells-ci
+  - #@ cleanup_old_published_light_stemcells("aws", "us", "us")
+  - #@ cleanup_old_published_light_stemcells("us-goverment", "us-gov", "us-gov")
 #@ for stemcell in data.values.oss:
 - name: cleanup-unpublished-(@= stemcell.os @)-aws-light-stemcells
   serial: true

--- a/tasks/light-aws/cleanup-ami.sh
+++ b/tasks/light-aws/cleanup-ami.sh
@@ -28,6 +28,15 @@ ami_destinations="$(aws ec2 describe-regions --output text --query "Regions[?Reg
 for region in $ami_destinations; do
     ami_list="[]"
 
+    if [ "${remove_public_images}" == "true" ]; then
+      results=$(aws ec2 describe-images \
+              --owners self \
+              --output json \
+              --region ${region} \
+              --filters "Name=name,Values=BOSH*" "Name=is-public,Values=true" \
+              --query 'sort_by(Images,&CreationDate)[?CreationDate<`'"$__PASTDUE"'`].{ImageId: ImageId, date:CreationDate, SnapshotId: BlockDeviceMappings[0].Ebs.SnapshotId,Version: Tags[?Key==`name`]|[0].Value}')
+    fi
+
     if [ -n "${os_name}" ]; then
       # 'ami_ids' array should be orderered by creation date
       results=$(aws ec2 describe-images \

--- a/tasks/light-aws/cleanup-ami.yml
+++ b/tasks/light-aws/cleanup-ami.yml
@@ -20,3 +20,4 @@ params:
   ami_keep_latest:            "5"  # Number of previous AMI to keep excluding those currently being running
   os_name:                    ""   # e.g ubuntu-jammy
   snapshot_id:                ""   # Snapshot id to delete
+  remove_public_images:       "false"


### PR DESCRIPTION
rfc-0010 established that we should do this, but apparently we never set it up?