### PR TITLE
Parameterize default vm type for gcp director config

### DIFF
--- a/pipelines/ubuntu-jammy/pipeline.yml
+++ b/pipelines/ubuntu-jammy/pipeline.yml
@@ -302,6 +302,7 @@ jobs:
           INTERNAL_GW: 10.100.(@= data.values.stemcell_details.subnet_int @).1
           RESERVED_RANGE: '10.100.(@= data.values.stemcell_details.subnet_int @).2 - 10.100.(@= data.values.stemcell_details.subnet_int @).9, 10.100.(@= data.values.stemcell_details.subnet_int @).62 - 10.100.(@= data.values.stemcell_details.subnet_int @).254'
           TAG: test-stemcells-ipv4
+          DEFAULT_VM_TYPE: e2-standard-2
       - task: test-stemcell
         attempts: 3
         file: bosh-stemcells-ci/tasks/test-stemcell.yml

--- a/tasks/gcp/deploy-director.sh
+++ b/tasks/gcp/deploy-director.sh
@@ -11,6 +11,19 @@ project_id: ${GCP_PROJECT_ID}
 zone: ${GCP_ZONE}
 preemptible: ${GCP_PREEMPTIBLE}
 tags: [${TAG}]
+default_vm_type: ${DEFAULT_VM_TYPE}
+EOF
+
+cat > default-vm-type-opsfile.yml <<EOF
+---
+- name: vm_types
+  path: /vm_types/name=default/cloud_properties/machine_type
+  type: replace
+  value: (( default_vm_type ))
+- name: vm_types
+  path: /vm_types/name=large/cloud_properties/machine_type
+  type: replace
+  value: (( default_vm_type ))
 EOF
 
 cat > network-variables.yml <<EOF
@@ -27,6 +40,7 @@ echo ${GCP_JSON_KEY} > gcp_creds.json
 bosh interpolate bosh-deployment/bosh.yml \
   -o bosh-deployment/gcp/cpi.yml \
   -o bosh-deployment/jumpbox-user.yml \
+  -o default-vm-type-opsfile.yml \
   --vars-store director-creds.yml \
   --vars-file director-vars.yml \
   --var-file gcp_credentials_json=gcp_creds.json \

--- a/tasks/gcp/deploy-director.yml
+++ b/tasks/gcp/deploy-director.yml
@@ -14,6 +14,7 @@ outputs:
   - name: director-state
 
 params:
+  DEFAULT_VM_TYPE: n1-standard-2 # chosen to match what is currently in https://github.com/cloudfoundry/bosh-deployment/blob/master/gcp/cloud-config.yml#L15
 
 
 run:


### PR DESCRIPTION
# Context

[test-stemcells-ipv4](https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/stemcells-ubuntu-jammy/jobs/test-stemcells-ipv4/builds/312) was failing due to the vm type n1-standard-2 not existing after moving the jammy pipeline eu-north-2 region. 

The vm type originates from the deploy-director task, which uses [bosh-deployment/gcp/cloud-config.yml](https://github.com/cloudfoundry/bosh-deployment/blob/master/gcp/cloud-config.yml#L15), which sets the default vm type as n1-standard-2.

# Changes
* allows deploy-director task to accept a param for default vm type, makes an opfile in the task.sh to replace what comes from bosh-deployment
* sets the default value of the parameter to match what is in bosh-deployment/gcp/cloud-config.yml to avoid breaking other things. Though, if the bosh-deployment value ever changes, this will be out of date.