### PR TITLE
Use correct metalink path for fetching USN data

### DIFF
--- a/tasks/build-release-metadata.sh
+++ b/tasks/build-release-metadata.sh
@@ -36,7 +36,7 @@ pushd bosh-linux-stemcell-builder
   if [[ "${OS_NAME}" == "ubuntu" ]]; then
     # Ensure URL for usn-log from metalink exists before attempting to download.
     touch usn-log.json
-    usn_metalink_path="bosh-stemcell/image-metalinks/#${BRANCH}/${BRANCH}/${OS_NAME}-${OS_VERSION}.meta4"
+    usn_metalink_path="bosh-stemcell/image-metalinks/${BRANCH}/${OS_NAME}-${OS_VERSION}.meta4"
     if [[ -n "$(meta4 file-urls --metalink "${usn_metalink_path}" --file usn-log.json)" ]]; then
       meta4 file-download --metalink "${usn_metalink_path}" --file usn-log.json usn-log.json --skip-hash-verification --skip-signature-verification
     fi


### PR DESCRIPTION
`#{BRANCH}` is invalid as a metalink path when used in the Noble pipeline. That is because the Noble branch does not have a `bosh-stemcell/image-metalink/#ubuntu-noble` directory, while the Jammy branch incorrectly has one where metalinks aren't updated. The correct metalink file to use is
`bosh-stemcell/ubuntu-{jammy,noble}/ubuntu-{jammy,noble}.meta4`. The correct branch is already checked out when this task is run.