### PR TITLE
Fix USN Fetching: Use USN Json from ubuntu-security-notices github repo

### DIFF
--- a/pipelines/ubuntu-jammy/pipeline.yml
+++ b/pipelines/ubuntu-jammy/pipeline.yml
@@ -85,13 +85,34 @@ jobs:
     - get: (@= data.values.stemcell_details.os @)-usn
       version: every
       trigger: true
+    - get: (@= data.values.stemcell_details.os @)-usn-gh-json
     - get: usn-log
+    - get: high-critical-unfound-usns
+  - task: check-if-usn-is-in-github
+    file: bosh-stemcells-ci/tasks/check-if-usn-is-in-github.yml
+    image: os-image-stemcell-builder
+    input_mapping:
+      usn: (@= data.values.stemcell_details.os @)-usn
+      usn-gh-json: (@= data.values.stemcell_details.os @)-usn-gh-json
+      unfound-usns: high-critical-unfound-usns
+    vars:
+      image_os_tag: (@= data.values.stemcell_details.os @)
+  - put: high-critical-unfound-usns
+    params:
+      file: updated-unfound-usns/usns.json
+      predefined_acl: publicRead
+  - task: verify-check-usn-was-successful
+    image: os-image-stemcell-builder
+    file: bosh-shared-ci/tasks/release/ensure-task-succeeded.yml
+    input_mapping:
+      task-output-folder: found-usns
   - try:
-      task: check-if-usn-is-applicable
-      file: bosh-stemcells-ci/tasks/check-if-usn-is-applicable.yml
+      task: check-if-usns-are-applicable
+      file: bosh-stemcells-ci/tasks/check-if-usns-are-applicable.yml
       image: os-image-stemcell-builder
       input_mapping:
-        usn: (@= data.values.stemcell_details.os @)-usn
+        usns: found-usns
+        usn-gh-json: (@= data.values.stemcell_details.os @)-usn-gh-json
       params:
         OS: (@= data.values.stemcell_details.os @)
       vars:
@@ -123,10 +144,14 @@ jobs:
       passed:
         - process-high-critical-cves
       trigger: true
+    - get: (@= data.values.stemcell_details.os @)-usn-gh-json
+      passed:
+        - process-high-critical-cves
   - task: check-usn-packages
     file: bosh-stemcells-ci/tasks/check-usn-packages.yml
     input_mapping:
       usn-log-in: usn-log
+      usn-gh-json: (@= data.values.stemcell_details.os @)-usn-gh-json
     params:
       OS: (@= data.values.stemcell_details.os @)
     vars:
@@ -153,12 +178,33 @@ jobs:
       version: every
       trigger: true
     - get: usn-log
+    - get: (@= data.values.stemcell_details.os @)-usn-gh-json
+    - get: low-medium-unfound-usns
+  - task: check-if-usn-is-in-github
+    file: bosh-stemcells-ci/tasks/check-if-usn-is-in-github.yml
+    image: os-image-stemcell-builder
+    input_mapping:
+      usn: (@= data.values.stemcell_details.os @)-usn
+      usn-gh-json: (@= data.values.stemcell_details.os @)-usn-gh-json
+      unfound-usns: low-medium-unfound-usns
+    vars:
+      image_os_tag: (@= data.values.stemcell_details.os @)
+  - put: low-medium-unfound-usns
+    params:
+      file: updated-unfound-usns/usns.json
+      predefined_acl: publicRead
+  - task: verify-check-usn-was-successful
+    image: os-image-stemcell-builder
+    file: bosh-shared-ci/tasks/release/ensure-task-succeeded.yml
+    input_mapping:
+      task-output-folder: found-usns
   - try:
-      task: check-if-usn-is-applicable
-      file: bosh-stemcells-ci/tasks/check-if-usn-is-applicable.yml
+      task: check-if-usns-are-applicable
+      file: bosh-stemcells-ci/tasks/check-if-usns-are-applicable.yml
       image: os-image-stemcell-builder
       input_mapping:
-        usn: (@= data.values.stemcell_details.os @)-usn-low-medium
+        usns: found-usns
+        usn-gh-json: (@= data.values.stemcell_details.os @)-usn-gh-json
       params:
         OS: (@= data.values.stemcell_details.os @)
       vars:
@@ -815,6 +861,24 @@ resources:
     initial_content_text: ""
     initial_version: '0'
 
+- name: high-critical-unfound-usns
+  type: gcs-resource
+  source:
+    bucket: bosh-stemcell-triggers
+    json_key: ((gcp_json_key))
+    versioned_file: (@= data.values.stemcell_details.branch @)/high-critical-unfound/usns.json
+    initial_content_text: ""
+    initial_version: '0'
+
+- name: low-medium-unfound-usns
+  type: gcs-resource
+  source:
+    bucket: bosh-stemcell-triggers
+    json_key: ((gcp_json_key))
+    versioned_file: (@= data.values.stemcell_details.branch @)/low-medium-unfound/usns.json
+    initial_content_text: ""
+    initial_version: '0'
+
 - name: stemcell-trigger
   type: gcs-resource
   source:
@@ -898,6 +962,13 @@ resources:
     priorities:
     - high
     - critical
+- name: (@= data.values.stemcell_details.os @)-usn-gh-json
+  type: git
+  source:
+    branch: main
+    uri: https://github.com/canonical/ubuntu-security-notices.git
+    paths:
+    - usn
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/ubuntu-noble/pipeline.yml
+++ b/pipelines/ubuntu-noble/pipeline.yml
@@ -84,22 +84,45 @@ jobs:
         - get: (@= data.values.stemcell_details.os @)-usn
           version: every
           trigger: true
+        - get: (@= data.values.stemcell_details.os @)-usn-gh-json
         - get: usn-log
+        - get: high-critical-unfound-usns
+    - task: check-if-usn-is-in-github
+      file: bosh-stemcells-ci/tasks/check-if-usn-is-in-github.yml
+      image: os-image-stemcell-builder
+      input_mapping:
+        usn: (@= data.values.stemcell_details.os @)-usn
+        usn-gh-json: (@= data.values.stemcell_details.os @)-usn-gh-json
+        unfound-usns: high-critical-unfound-usns
+      vars:
+        image_os_tag: (@= data.values.stemcell_details.os @)
+    - put: high-critical-unfound-usns
+      params:
+        file: updated-unfound-usns/usns.json
+        predefined_acl: publicRead
+    - task: verify-check-usn-was-successful
+      image: os-image-stemcell-builder
+      file: bosh-shared-ci/tasks/release/ensure-task-succeeded.yml
+      input_mapping:
+        task-output-folder: found-usns
     - try:
-        task: check-if-usn-is-applicable
-        file: bosh-stemcells-ci/tasks/check-if-usn-is-applicable.yml
+        task: check-if-usns-are-applicable
+        file: bosh-stemcells-ci/tasks/check-if-usns-are-applicable.yml
         image: os-image-stemcell-builder
         input_mapping:
-          usn: (@= data.values.stemcell_details.os @)-usn
+          usns: found-usns
+          usn-gh-json: (@= data.values.stemcell_details.os @)-usn-gh-json
         params:
           OS: (@= data.values.stemcell_details.os @)
         vars:
           image_os_tag: (@= data.values.stemcell_details.os @)
         on_success:
-          put: usn-log
-          params:
-            file: updated-usn-log/usn-log.json
-            predefined_acl: publicRead
+          in_parallel:
+            steps:
+            - put: usn-log
+              params:
+                file: updated-usn-log/usn-log.json
+                predefined_acl: publicRead
     - task: verify-check-usn-was-successful
       image: os-image-stemcell-builder
       file: bosh-shared-ci/tasks/release/ensure-task-succeeded.yml
@@ -116,10 +139,14 @@ jobs:
           passed:
             - process-high-critical-cves
           trigger: true
+        - get: (@= data.values.stemcell_details.os @)-usn-gh-json
+          passed:
+            - process-high-critical-cves
     - task: check-usn-packages
       file: bosh-stemcells-ci/tasks/check-usn-packages.yml
       input_mapping:
         usn-log-in: usn-log
+        usn-gh-json: (@= data.values.stemcell_details.os @)-usn-gh-json
       params:
         OS: (@= data.values.stemcell_details.os @)
       vars:
@@ -146,12 +173,33 @@ jobs:
           version: every
           trigger: true
         - get: usn-log
+        - get: (@= data.values.stemcell_details.os @)-usn-gh-json
+        - get: low-medium-unfound-usns
+    - task: check-if-usn-is-in-github
+      file: bosh-stemcells-ci/tasks/check-if-usn-is-in-github.yml
+      image: os-image-stemcell-builder
+      input_mapping:
+        usn: (@= data.values.stemcell_details.os @)-usn
+        usn-gh-json: (@= data.values.stemcell_details.os @)-usn-gh-json
+        unfound-usns: low-medium-unfound-usns
+      vars:
+        image_os_tag: (@= data.values.stemcell_details.os @)
+    - put: low-medium-unfound-usns
+      params:
+        file: updated-unfound-usns/usns.json
+        predefined_acl: publicRead
+    - task: verify-check-usn-was-successful
+      image: os-image-stemcell-builder
+      file: bosh-shared-ci/tasks/release/ensure-task-succeeded.yml
+      input_mapping:
+        task-output-folder: found-usns
     - try:
-        task: check-if-usn-is-applicable
-        file: bosh-stemcells-ci/tasks/check-if-usn-is-applicable.yml
+        task: check-if-usns-are-applicable
+        file: bosh-stemcells-ci/tasks/check-if-usns-are-applicable.yml
         image: os-image-stemcell-builder
         input_mapping:
-          usn: (@= data.values.stemcell_details.os @)-usn-low-medium
+          usns: found-usns
+          usn-gh-json: (@= data.values.stemcell_details.os @)-usn-gh-json
         params:
           OS: (@= data.values.stemcell_details.os @)
         vars:
@@ -743,6 +791,24 @@ resources:
     initial_content_text: ""
     initial_version: '0'
 
+- name: high-critical-unfound-usns
+  type: gcs-resource
+  source:
+    bucket: bosh-stemcell-triggers
+    json_key: ((gcp_json_key))
+    versioned_file: (@= data.values.stemcell_details.branch @)/high-critical-unfound/usns.json
+    initial_content_text: ""
+    initial_version: '0'
+
+- name: low-medium-unfound-usns
+  type: gcs-resource
+  source:
+    bucket: bosh-stemcell-triggers
+    json_key: ((gcp_json_key))
+    versioned_file: (@= data.values.stemcell_details.branch @)/low-medium-unfound/usns.json
+    initial_content_text: ""
+    initial_version: '0'
+
 - name: stemcell-trigger
   type: gcs-resource
   source:
@@ -823,6 +889,13 @@ resources:
     priorities:
     - high
     - critical
+- name: (@= data.values.stemcell_details.os @)-usn-gh-json
+  type: git
+  source:
+    branch: main
+    uri: https://github.com/canonical/ubuntu-security-notices.git
+    paths:
+    - usn
 - name: slack-alert
   type: slack-notification
   source:

--- a/tasks/check-if-usn-is-applicable.sh
+++ b/tasks/check-if-usn-is-applicable.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${0}" )" && pwd )"
 
 source "${SCRIPT_DIR}/usn-processing/usn-shared-functions.sh"
 usn_json="${PWD}/usn/usn.json"
-process_usns "${usn_json}"
+process_usns "${usn_json}" "usn-gh-json/usn"
 
 
 if [ "$PACKAGE_INCLUDED_IN_STEMCELL" == true ]

--- a/tasks/check-if-usn-is-applicable.yml
+++ b/tasks/check-if-usn-is-applicable.yml
@@ -11,6 +11,7 @@ inputs:
   - name: bosh-stemcells-ci
   - name: usn-log
   - name: usn
+  - name: usn-gh-json
 
 outputs:
   - name: updated-usn-log

--- a/tasks/check-if-usn-is-in-github.sh
+++ b/tasks/check-if-usn-is-in-github.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+usn_json="${PWD}/usn/usn.json"
+
+# add the new usn to the list of unfound usns
+touch joined-usns
+cp unfound-usns/usns.json joined-usns
+cat "${usn_json}" >> joined-usns
+
+# turn the unfound usns into an array
+mapfile -t UNFOUND_USNS < joined-usns
+
+# check if each of the unfound usns is in github
+touch found-usns/usns.json
+touch updated-unfound-usns/usns.json
+for usn in "${UNFOUND_USNS[@]}"; do
+    id=$(echo $usn | jq -r '.url' | cut -d '/' -f6 | cut -d '-' -f2,3)
+    echo "checking for USN-${id} in github..."
+
+    if [[ -f "usn-gh-json/usn/${id}.json" ]]; then
+        echo "found ${id}.json "
+        echo $usn >> found-usns/usns.json
+    else
+        echo "${id}.json not found"
+        echo $usn >> updated-unfound-usns/usns.json
+    fi
+done

--- a/tasks/check-if-usn-is-in-github.yml
+++ b/tasks/check-if-usn-is-in-github.yml
@@ -1,0 +1,21 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: bosh/os-image-stemcell-builder
+    tag: "((image_os_tag))"
+
+inputs:
+  - name: bosh-stemcells-ci
+  - name: usn
+  - name: usn-gh-json
+  - name: unfound-usns
+
+outputs:
+  - name: found-usns
+  - name: updated-unfound-usns
+
+run:
+  path: bosh-stemcells-ci/tasks/check-if-usn-is-in-github.sh
+

--- a/tasks/check-if-usns-are-applicable.sh
+++ b/tasks/check-if-usns-are-applicable.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${0}" )" && pwd )"
+
+source "${SCRIPT_DIR}/usn-processing/usn-shared-functions.sh"
+
+packages_included_in_stemcell=false
+mapfile -t FOUND_USNS < usns/usns.json
+for usn in "${FOUND_USNS[@]}"; do
+  id=$(echo $usn | jq -r '.url' | cut -d '/' -f6 | cut -d '-' -f2,3)
+
+  usn_json="${PWD}/usn.json"
+  echo $usn > $usn_json
+  process_usns "${usn_json}" "usn-gh-json/usn"
+
+
+  if [ "$PACKAGE_INCLUDED_IN_STEMCELL" == true ]
+  then
+    jq -s --slurpfile new_usn ${usn_json} '. + $new_usn | unique_by(.url) | .[]' >> updated-usn-log/usn-log.json < usn-log/usn-log.json
+    packages_included_in_stemcell=true
+  else
+    echo "Packages for USN-${id} are not included in stemcell"
+  fi
+
+  PACKAGE_INCLUDED_IN_STEMCELL=false
+done
+
+if $packages_included_in_stemcell; then
+  echo "true" > updated-usn-log/success
+  exit 0
+else
+  echo "true" > updated-usn-log/success
+  exit 1
+fi

--- a/tasks/check-if-usns-are-applicable.yml
+++ b/tasks/check-if-usns-are-applicable.yml
@@ -1,0 +1,24 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: bosh/os-image-stemcell-builder
+    tag: "((image_os_tag))"
+
+inputs:
+  - name: bosh-linux-stemcell-builder
+  - name: bosh-stemcells-ci
+  - name: usn-log
+  - name: usns
+  - name: usn-gh-json
+
+outputs:
+  - name: updated-usn-log
+
+run:
+  path: bosh-stemcells-ci/tasks/check-if-usns-are-applicable.sh
+
+params:
+  OS:
+  ESM_TOKEN:

--- a/tasks/check-usn-packages.sh
+++ b/tasks/check-usn-packages.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${0}" )" && pwd )"
 
 source "${SCRIPT_DIR}/usn-processing/usn-shared-functions.sh"
 
-process_usns "usn-log-in/usn-log.json"
+process_usns "usn-log-in/usn-log.json" "usn-gh-json/usn"
 
 
 if [ "$ALL_PACKAGE_VERSIONS_AVAILABLE" != true ]

--- a/tasks/check-usn-packages.yml
+++ b/tasks/check-usn-packages.yml
@@ -10,6 +10,7 @@ inputs:
   - name: bosh-linux-stemcell-builder
   - name: bosh-stemcells-ci
   - name: usn-log-in
+  - name: usn-gh-json
 
 run:
   path: bosh-stemcells-ci/tasks/check-usn-packages.sh


### PR DESCRIPTION
# Context

The existing code is busted 😞 https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/stemcells-ubuntu-jammy?group=automatic-triggers

The code ([pipeline example](https://github.com/cloudfoundry/bosh-stemcells-ci/blob/master/pipelines/ubuntu-jammy/pipeline.yml#L91)/[task code](https://github.com/cloudfoundry/bosh-stemcells-ci/blob/master/tasks/usn-processing/usn-shared-functions.sh#L71-L73)) that fetches the USN info fetches `${USN_URL}.json` and this is (has been) returning `503` with no JSON which causes `jq` parsing to fail. It may be that HTTP based access is no longer available / provided.

There does appear to be JSON available at https://github.com/canonical/ubuntu-security-notices/blob/main/usn/${USN_NUMBER}.json

# Changes

* adds a new task to check if the USN exists in https://github.com/canonical/ubuntu-security-notices/blob/main/usn/${USN_NUMBER}.json
  * to cover the case that the USN hasn't been committed to github when the trigger happens, the task will log any USNs not found, and process them in addition to the next USN that triggers. We could also add timer trigger to this job if we want, but I didn't.
* updates the existing code that checks if the USN is applicable to handle multiple USNs (to cover the case that the previous task finds the triggering USN in github, as well as one that wasn't found earlier). This should then feed into the rest of the USN processing code that assembles release notes with no changes.

# Help
- [ ] I can't access the GCP account, so I think I will need help creating some new buckets
- [ ] I also can't set the pipeline. I've tried out this new flow in a test pipeline, but I haven't proved that everything is okay in this Concourse instance.