### PR TITLE
Attempt to scale skeletal deployment

### DIFF
--- a/tasks/light-google/skeletal-deployment.yml
+++ b/tasks/light-google/skeletal-deployment.yml
@@ -19,7 +19,7 @@ resource_pools:
   stemcell:
     url: file://assets/stemcell.tgz
   cloud_properties:
-    machine_type: f1-micro
+    machine_type: n1-standard-2
     root_disk_type: pd-standard
     zone: ((gce_zone))
     tags:


### PR DESCRIPTION
seeing this failure:
Deploying:
  Creating instance skeletal/0:
    Waiting until instance is ready:
      Post "https://mbus:<redacted>@34.59.81.185:6868/agent": dial tcp 34.59.81.185:6868: i/o timeout

and using gcloud compute ssh .... --troubleshoot recommended scaling up the cpus.